### PR TITLE
Remove redundant new_preconnection constructor

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Pre-commit hook to run cargo fmt
+
+echo "Running cargo fmt..."
+
+# Check if cargo is available
+if ! command -v cargo &> /dev/null; then
+    echo "cargo could not be found. Please install Rust."
+    exit 1
+fi
+
+# Run cargo fmt in check mode
+if ! cargo fmt -- --check; then
+    echo ""
+    echo "Code formatting issues detected!"
+    echo "Please run 'cargo fmt' to fix formatting before committing."
+    echo ""
+    exit 1
+fi
+
+echo "Formatting check passed!"
+exit 0

--- a/README.md
+++ b/README.md
@@ -180,6 +180,22 @@ int main() {
 
 Contributions are welcome! Please feel free to open an issue or submit a pull request.
 
+### Setting Up Git Hooks
+
+This project uses git hooks to ensure code quality. To set up the pre-commit hook that runs `cargo fmt`:
+
+**On Unix/Linux/macOS:**
+```bash
+./setup-hooks.sh
+```
+
+**On Windows:**
+```cmd
+setup-hooks.bat
+```
+
+This will configure git to run `cargo fmt --check` before each commit, ensuring all code is properly formatted.
+
 ## License
 
 This project is licensed under the MIT License.

--- a/setup-hooks.bat
+++ b/setup-hooks.bat
@@ -1,0 +1,13 @@
+@echo off
+REM Script to set up git hooks for the project on Windows
+
+echo Setting up git hooks...
+
+REM Configure git to use the .githooks directory
+git config core.hooksPath .githooks
+
+echo.
+echo Git hooks configured successfully!
+echo The pre-commit hook will now run 'cargo fmt --check' before each commit.
+echo.
+echo To bypass the hook (not recommended), use: git commit --no-verify

--- a/setup-hooks.sh
+++ b/setup-hooks.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Script to set up git hooks for the project
+
+echo "Setting up git hooks..."
+
+# Configure git to use the .githooks directory
+git config core.hooksPath .githooks
+
+echo "Git hooks configured successfully!"
+echo "The pre-commit hook will now run 'cargo fmt --check' before each commit."
+echo ""
+echo "To bypass the hook (not recommended), use: git commit --no-verify"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub use error::{Result, TransportServicesError};
 pub use framer::{Framer, FramerStack, LengthPrefixFramer};
 pub use listener::Listener;
 pub use message::{Message, MessageContext};
-pub use preconnection::{new_preconnection, Preconnection};
+pub use preconnection::Preconnection;
 pub use types::*;
 
 #[cfg(test)]

--- a/src/preconnection.rs
+++ b/src/preconnection.rs
@@ -9,22 +9,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
 
-/// Create a new Preconnection as defined in RFC Section 6
-/// This is the primary way to create a Preconnection object
-pub fn new_preconnection(
-    local_endpoints: Vec<LocalEndpoint>,
-    remote_endpoints: Vec<RemoteEndpoint>,
-    transport_properties: TransportProperties,
-    security_parameters: SecurityParameters,
-) -> Preconnection {
-    Preconnection::new(
-        local_endpoints,
-        remote_endpoints,
-        transport_properties,
-        security_parameters,
-    )
-}
-
 /// A Preconnection represents a potential Connection
 /// It is a passive object that maintains the state describing
 /// the properties of a Connection that might exist in the future

--- a/src/test_formatting.rs
+++ b/src/test_formatting.rs
@@ -1,0 +1,5 @@
+// Test file with bad formatting
+fn main() {
+println!("Hello");
+        println!("World");
+    }

--- a/src/test_formatting.rs
+++ b/src/test_formatting.rs
@@ -1,5 +1,0 @@
-// Test file with bad formatting
-fn main() {
-println!("Hello");
-        println!("World");
-    }

--- a/src/tests/background_reading_tests.rs
+++ b/src/tests/background_reading_tests.rs
@@ -29,7 +29,7 @@ async fn test_background_reading_receives_messages() {
     });
 
     // Create connection
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder().socket_address(addr).build()],
         TransportProperties::default(),
@@ -103,7 +103,7 @@ async fn test_background_reading_with_framing() {
     });
 
     // Create connection with framing
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder().socket_address(addr).build()],
         TransportProperties::default(),
@@ -164,7 +164,7 @@ async fn test_background_reading_handles_connection_close() {
     });
 
     // Create connection
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder().socket_address(addr).build()],
         TransportProperties::default(),
@@ -235,7 +235,7 @@ async fn test_background_reading_concurrent_with_receive() {
     });
 
     // Create connection
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder().socket_address(addr).build()],
         TransportProperties::default(),

--- a/src/tests/connection_group_tests.rs
+++ b/src/tests/connection_group_tests.rs
@@ -1,8 +1,8 @@
 //! Unit tests for Connection Groups functionality
 
 use crate::{
-    preconnection::new_preconnection, ConnectionGroup, ConnectionState, LocalEndpoint, Preference,
-    RemoteEndpoint, SecurityParameters, TransportProperties,
+    ConnectionGroup, ConnectionState, LocalEndpoint, Preconnection, Preference, RemoteEndpoint,
+    SecurityParameters, TransportProperties,
 };
 use std::time::Duration;
 use tokio::net::TcpListener;
@@ -18,7 +18,7 @@ async fn test_connection_clone_basic() {
         .socket_address(server_addr)
         .build();
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![remote],
         TransportProperties::default(),
@@ -87,7 +87,7 @@ async fn test_connection_clone_basic() {
 
 #[tokio::test]
 async fn test_connection_clone_only_established() {
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder()
             .ip_address("127.0.0.1".parse().unwrap())
@@ -132,7 +132,7 @@ async fn test_connection_group_shared_properties() {
         .socket_address(server_addr)
         .build();
 
-    let preconn = new_preconnection(vec![], vec![remote], props, SecurityParameters::default());
+    let preconn = Preconnection::new(vec![], vec![remote], props, SecurityParameters::default());
 
     // Create initial connection
     let conn1 = preconn.initiate().await.unwrap();
@@ -180,7 +180,7 @@ async fn test_connection_group_multiple_clones() {
         .socket_address(server_addr)
         .build();
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![remote],
         TransportProperties::default(),
@@ -250,7 +250,7 @@ async fn test_connection_group_close() {
         .socket_address(server_addr)
         .build();
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![remote],
         TransportProperties::default(),
@@ -284,7 +284,7 @@ async fn test_connection_group_close() {
 #[tokio::test]
 async fn test_connection_without_group() {
     // Create a connection that won't be cloned
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder()
             .ip_address("127.0.0.1".parse().unwrap())

--- a/src/tests/connection_properties_tests.rs
+++ b/src/tests/connection_properties_tests.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 #[tokio::test]
 async fn test_set_and_get_properties() {
     // Create a connection for testing
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder()
             .hostname("example.com")
@@ -42,7 +42,7 @@ async fn test_set_and_get_properties() {
 
 #[tokio::test]
 async fn test_connection_properties_defaults() {
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder()
             .hostname("example.com")
@@ -84,7 +84,7 @@ async fn test_connection_properties_defaults() {
 
 #[tokio::test]
 async fn test_readonly_properties() {
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder()
             .hostname("example.com")
@@ -126,7 +126,7 @@ async fn test_readonly_properties() {
 
 #[tokio::test]
 async fn test_readonly_property_rejection() {
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder()
             .hostname("example.com")
@@ -165,7 +165,7 @@ async fn test_readonly_property_rejection() {
 
 #[tokio::test]
 async fn test_timeout_properties() {
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder()
             .hostname("example.com")
@@ -205,7 +205,7 @@ async fn test_timeout_properties() {
 
 #[tokio::test]
 async fn test_capacity_profile() {
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder()
             .hostname("example.com")
@@ -243,7 +243,7 @@ async fn test_capacity_profile() {
 
 #[tokio::test]
 async fn test_rate_limits() {
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder()
             .hostname("example.com")

--- a/src/tests/connection_termination_tests.rs
+++ b/src/tests/connection_termination_tests.rs
@@ -29,7 +29,7 @@ async fn create_test_connection() -> Connection {
     });
 
     // Create connection
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder().socket_address(addr).build()],
         TransportProperties::default(),
@@ -244,7 +244,7 @@ async fn test_remote_close_detection() {
         });
 
         // Create connection
-        let preconn = new_preconnection(
+        let preconn = Preconnection::new(
             vec![],
             vec![RemoteEndpoint::builder().socket_address(addr).build()],
             TransportProperties::default(),

--- a/src/tests/connection_tests.rs
+++ b/src/tests/connection_tests.rs
@@ -39,7 +39,7 @@ async fn test_connection_establishment() {
             .port(server_addr.port())
             .build();
 
-        let preconn = new_preconnection(
+        let preconn = Preconnection::new(
             vec![],
             vec![remote],
             TransportProperties::default(),
@@ -84,7 +84,7 @@ async fn test_connection_send_receive() {
             .port(server_addr.port())
             .build();
 
-        let preconn = new_preconnection(
+        let preconn = Preconnection::new(
             vec![],
             vec![remote],
             TransportProperties::default(),
@@ -123,7 +123,7 @@ async fn test_connection_events() {
             .port(server_addr.port())
             .build();
 
-        let preconn = new_preconnection(
+        let preconn = Preconnection::new(
             vec![],
             vec![remote],
             TransportProperties::default(),
@@ -172,7 +172,7 @@ async fn test_connection_timeout() {
         .port(12345)
         .build();
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![remote],
         TransportProperties::default(),
@@ -225,7 +225,7 @@ async fn test_queued_messages() {
             .port(server_addr.port())
             .build();
 
-        let preconn = new_preconnection(
+        let preconn = Preconnection::new(
             vec![],
             vec![remote],
             TransportProperties::default(),

--- a/src/tests/endpoint_management_tests.rs
+++ b/src/tests/endpoint_management_tests.rs
@@ -4,7 +4,7 @@ use crate::*;
 
 #[tokio::test]
 async fn test_add_remote_endpoint_to_establishing_connection() {
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder()
             .hostname("example.com")
@@ -44,7 +44,7 @@ async fn test_add_duplicate_remote_endpoint() {
         .port(443)
         .build();
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![endpoint.clone()],
         TransportProperties::default(),
@@ -67,7 +67,7 @@ async fn test_add_duplicate_remote_endpoint() {
 
 #[tokio::test]
 async fn test_add_remote_to_closed_connection() {
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder()
             .hostname("example.com")
@@ -105,7 +105,7 @@ async fn test_add_remote_to_closed_connection() {
 
 #[tokio::test]
 async fn test_add_local_endpoint_to_establishing_connection() {
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder()
             .hostname("example.com")
@@ -143,7 +143,7 @@ async fn test_add_duplicate_local_endpoint() {
         identifiers: vec![EndpointIdentifier::Interface("eth0".to_string())],
     };
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![endpoint.clone()],
         vec![RemoteEndpoint::builder()
             .hostname("example.com")
@@ -169,7 +169,7 @@ async fn test_add_duplicate_local_endpoint() {
 
 #[tokio::test]
 async fn test_add_local_to_closed_connection() {
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder()
             .hostname("example.com")

--- a/src/tests/group_termination_tests.rs
+++ b/src/tests/group_termination_tests.rs
@@ -34,7 +34,7 @@ async fn test_close_group_closes_all_connections() {
     });
 
     // Create first connection
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder().socket_address(addr).build()],
         TransportProperties::default(),
@@ -106,7 +106,7 @@ async fn test_abort_group_aborts_all_connections() {
     });
 
     // Create first connection
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder().socket_address(addr).build()],
         TransportProperties::default(),
@@ -184,7 +184,7 @@ async fn test_close_group_on_ungrouped_connection() {
         });
 
         // Create a real connection (not part of a group)
-        let preconn = new_preconnection(
+        let preconn = Preconnection::new(
             vec![],
             vec![RemoteEndpoint::builder().socket_address(addr).build()],
             TransportProperties::default(),
@@ -243,7 +243,7 @@ async fn test_abort_group_on_ungrouped_connection() {
         });
 
         // Create a real connection (not part of a group)
-        let preconn = new_preconnection(
+        let preconn = Preconnection::new(
             vec![],
             vec![RemoteEndpoint::builder().socket_address(addr).build()],
             TransportProperties::default(),

--- a/src/tests/integration_tests.rs
+++ b/src/tests/integration_tests.rs
@@ -56,7 +56,7 @@ async fn test_multiple_connections() {
             .port(server_addr.port())
             .build();
 
-        let preconn = new_preconnection(
+        let preconn = Preconnection::new(
             vec![],
             vec![remote],
             TransportProperties::default(),
@@ -113,7 +113,7 @@ async fn test_transport_properties_application() {
             .connection_priority(100)
             .build();
 
-        let preconn = new_preconnection(
+        let preconn = Preconnection::new(
             vec![],
             vec![remote],
             props,
@@ -157,7 +157,7 @@ async fn test_connection_with_local_endpoint() {
             .port(server_addr.port())
             .build();
 
-        let preconn = new_preconnection(
+        let preconn = Preconnection::new(
             vec![local],
             vec![remote],
             TransportProperties::default(),
@@ -193,7 +193,7 @@ async fn test_connection_clone_group() {
             .port(server_addr.port())
             .build();
 
-        let preconn = new_preconnection(
+        let preconn = Preconnection::new(
             vec![],
             vec![remote],
             TransportProperties::default(),
@@ -247,7 +247,7 @@ async fn test_hostname_resolution() {
         .port(server_addr.port())
         .build();
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![remote],
         TransportProperties::default(),
@@ -298,7 +298,7 @@ async fn test_multicast_endpoint() {
         .hop_limit(1)
         .build();
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![local],
         vec![remote],
         TransportProperties::default(),
@@ -322,7 +322,7 @@ async fn test_protocol_specific_endpoint() {
         .protocol(Protocol::TCP)
         .build();
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![tcp_remote],
         TransportProperties::default(),
@@ -353,7 +353,7 @@ async fn test_listener_accept_connection() {
         .port(0)
         .build();
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![local],
         vec![],
         TransportProperties::default(),
@@ -390,7 +390,7 @@ async fn test_client_server_data_exchange() {
         .port(0)
         .build();
 
-    let server_preconn = new_preconnection(
+    let server_preconn = Preconnection::new(
         vec![local],
         vec![],
         TransportProperties::default(),
@@ -419,7 +419,7 @@ async fn test_client_server_data_exchange() {
         .port(listen_addr.port())
         .build();
 
-    let client_preconn = new_preconnection(
+    let client_preconn = Preconnection::new(
         vec![],
         vec![remote],
         TransportProperties::default(),
@@ -455,7 +455,7 @@ async fn test_listener_multiple_clients() {
         .port(0)
         .build();
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![local],
         vec![],
         TransportProperties::default(),
@@ -513,7 +513,7 @@ async fn test_listener_connection_limit_integration() {
         .port(0)
         .build();
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![local],
         vec![],
         TransportProperties::default(),
@@ -571,7 +571,7 @@ async fn test_rendezvous_peer_to_peer() {
         .port(0) // Will be updated with peer B's actual port
         .build();
 
-    let preconn_a = new_preconnection(
+    let preconn_a = Preconnection::new(
         vec![peer_a_local],
         vec![peer_a_remote],
         TransportProperties::default(),
@@ -592,7 +592,7 @@ async fn test_rendezvous_peer_to_peer() {
         .socket_address(addr_a) // Connect to peer A
         .build();
 
-    let preconn_b = new_preconnection(
+    let preconn_b = Preconnection::new(
         vec![peer_b_local],
         vec![peer_b_remote],
         TransportProperties::default(),
@@ -651,7 +651,7 @@ async fn test_rendezvous_with_transport_properties() {
         .port(54327) // Non-listening port
         .build();
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![local],
         vec![remote],
         props,
@@ -690,7 +690,7 @@ async fn test_message_properties_integration() {
         .socket_address(server_addr)
         .build();
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![remote],
         TransportProperties::default(),
@@ -795,7 +795,7 @@ async fn test_full_send_receive_flow() {
             .socket_address(server_addr)
             .build();
 
-        let preconn = new_preconnection(
+        let preconn = Preconnection::new(
             vec![],
             vec![remote],
             TransportProperties::default(),

--- a/src/tests/lifecycle_events_tests.rs
+++ b/src/tests/lifecycle_events_tests.rs
@@ -16,7 +16,7 @@ async fn create_test_connection() -> Connection {
     });
 
     // Create connection
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder().socket_address(addr).build()],
         TransportProperties::default(),
@@ -95,7 +95,7 @@ async fn test_enable_soft_error_notifications() {
         let mut transport_props = TransportProperties::default();
         transport_props.selection_properties.soft_error_notify = Preference::Require;
 
-        let preconn = new_preconnection(
+        let preconn = Preconnection::new(
             vec![],
             vec![RemoteEndpoint::builder().socket_address(addr).build()],
             transport_props,
@@ -136,7 +136,7 @@ async fn test_lifecycle_events_on_connection_group() {
         });
 
         // Create first connection
-        let preconn = new_preconnection(
+        let preconn = Preconnection::new(
             vec![],
             vec![RemoteEndpoint::builder().socket_address(addr).build()],
             TransportProperties::default(),
@@ -198,7 +198,7 @@ async fn test_soft_error_during_data_transfer() {
 async fn test_path_change_on_endpoint_addition() {
     tokio::time::timeout(Duration::from_secs(5), async {
         // Create connection in establishing state
-        let preconn = new_preconnection(
+        let preconn = Preconnection::new(
             vec![],
             vec![RemoteEndpoint::builder()
                 .hostname("example.com")

--- a/src/tests/listener_tests.rs
+++ b/src/tests/listener_tests.rs
@@ -1,15 +1,15 @@
 //! Unit tests for Listener implementation
 
 use crate::{
-    listener::ListenerEvent, preconnection::new_preconnection, EndpointIdentifier, LocalEndpoint,
-    SecurityParameters, TransportProperties,
+    listener::ListenerEvent, EndpointIdentifier, LocalEndpoint, Preconnection, SecurityParameters,
+    TransportProperties,
 };
 use std::time::Duration;
 use tokio::time::{sleep, timeout};
 
 #[tokio::test]
 async fn test_listener_creation() {
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![LocalEndpoint {
             identifiers: vec![
                 EndpointIdentifier::Port(0), // Let OS choose port
@@ -35,7 +35,7 @@ async fn test_listener_creation() {
 #[tokio::test]
 async fn test_listener_with_specific_port() {
     let port = 54321;
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![LocalEndpoint {
             identifiers: vec![
                 EndpointIdentifier::IpAddress("127.0.0.1".parse().unwrap()),
@@ -60,7 +60,7 @@ async fn test_listener_with_specific_port() {
 
 #[tokio::test]
 async fn test_listener_no_endpoints_error() {
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![], // No local endpoints
         vec![],
         TransportProperties::default(),
@@ -79,7 +79,7 @@ async fn test_listener_no_endpoints_error() {
 async fn test_listener_accept_with_connection() {
     use tokio::net::TcpStream;
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![LocalEndpoint {
             identifiers: vec![
                 EndpointIdentifier::IpAddress("127.0.0.1".parse().unwrap()),
@@ -127,7 +127,7 @@ async fn test_listener_accept_with_connection() {
 
 #[tokio::test]
 async fn test_listener_stop() {
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![LocalEndpoint {
             identifiers: vec![EndpointIdentifier::Port(0)],
         }],
@@ -152,7 +152,7 @@ async fn test_listener_stop() {
 async fn test_listener_connection_limit() {
     use tokio::net::TcpStream;
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![LocalEndpoint {
             identifiers: vec![
                 EndpointIdentifier::IpAddress("127.0.0.1".parse().unwrap()),
@@ -199,7 +199,7 @@ async fn test_listener_connection_limit() {
 async fn test_listener_event_stream() {
     use tokio::net::TcpStream;
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![LocalEndpoint {
             identifiers: vec![
                 EndpointIdentifier::IpAddress("127.0.0.1".parse().unwrap()),
@@ -245,7 +245,7 @@ async fn test_listener_event_stream() {
 async fn test_listener_multiple_connections() {
     use tokio::net::TcpStream;
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![LocalEndpoint {
             identifiers: vec![
                 EndpointIdentifier::IpAddress("127.0.0.1".parse().unwrap()),
@@ -303,7 +303,7 @@ async fn test_listener_socket_address_endpoint() {
     use std::net::SocketAddr;
 
     let socket_addr: SocketAddr = "127.0.0.1:54322".parse().unwrap();
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![LocalEndpoint {
             identifiers: vec![EndpointIdentifier::SocketAddress(socket_addr)],
         }],
@@ -323,7 +323,7 @@ async fn test_listener_socket_address_endpoint() {
 
 #[tokio::test]
 async fn test_listener_bind_any_address() {
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![LocalEndpoint {
             identifiers: vec![], // No specific address - should bind to 0.0.0.0:0
         }],

--- a/src/tests/message_sending_tests.rs
+++ b/src/tests/message_sending_tests.rs
@@ -1,8 +1,8 @@
 //! Unit tests for Message Sending functionality
 
 use crate::{
-    message::SendContext, preconnection::new_preconnection, ConnectionEvent, ConnectionState,
-    Message, RemoteEndpoint, SecurityParameters, TransportProperties,
+    message::SendContext, ConnectionEvent, ConnectionState, Message, Preconnection, RemoteEndpoint,
+    SecurityParameters, TransportProperties,
 };
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -30,7 +30,7 @@ async fn test_basic_message_send() {
         .socket_address(server_addr)
         .build();
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![remote],
         TransportProperties::default(),
@@ -87,7 +87,7 @@ async fn test_message_with_id() {
         .socket_address(server_addr)
         .build();
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![remote],
         TransportProperties::default(),
@@ -141,7 +141,7 @@ async fn test_partial_sends() {
         .socket_address(server_addr)
         .build();
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![remote],
         TransportProperties::default(),
@@ -201,7 +201,7 @@ async fn test_message_batching() {
         .socket_address(server_addr)
         .build();
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![remote],
         TransportProperties::default(),
@@ -265,7 +265,7 @@ async fn test_message_expiry() {
         .socket_address(server_addr)
         .build();
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![remote],
         TransportProperties::default(),
@@ -333,7 +333,7 @@ async fn test_initiate_with_send() {
         .socket_address(server_addr)
         .build();
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![remote],
         TransportProperties::default(),
@@ -373,7 +373,7 @@ async fn test_send_on_closed_connection() {
         }
     });
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder().socket_address(addr).build()],
         TransportProperties::default(),
@@ -423,7 +423,7 @@ async fn test_send_with_event_notifier() {
         .socket_address(server_addr)
         .build();
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![remote],
         TransportProperties::default(),

--- a/src/tests/mtu_tests.rs
+++ b/src/tests/mtu_tests.rs
@@ -18,7 +18,7 @@ async fn test_tcp_mss_query() {
     });
 
     // Create a connection
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder().socket_address(addr).build()],
         TransportProperties::default(),
@@ -77,7 +77,7 @@ async fn test_tcp_mss_query() {
 
 #[tokio::test]
 async fn test_mss_property_not_set_before_connection() {
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder()
             .hostname("example.com")

--- a/src/tests/preconnection_tests.rs
+++ b/src/tests/preconnection_tests.rs
@@ -2,7 +2,7 @@ use crate::*;
 
 #[tokio::test]
 async fn test_new_preconnection() {
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![],
         TransportProperties::default(),
@@ -24,7 +24,7 @@ async fn test_preconnection_with_endpoints() {
         .port(8080)
         .build();
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![local],
         vec![remote],
         TransportProperties::default(),
@@ -97,7 +97,7 @@ async fn test_security_parameters() {
         .build();
 
     // Test with disabled security
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![remote.clone()],
         TransportProperties::default(),
@@ -106,7 +106,7 @@ async fn test_security_parameters() {
     assert!(preconn.resolve().await.is_ok());
 
     // Test with opportunistic security
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![remote.clone()],
         TransportProperties::default(),
@@ -125,7 +125,7 @@ async fn test_security_parameters() {
         SecurityParameterValue::Strings(vec!["h2".to_string(), "http/1.1".to_string()]),
     );
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![remote],
         TransportProperties::default(),

--- a/src/tests/property_updates_tests.rs
+++ b/src/tests/property_updates_tests.rs
@@ -19,7 +19,7 @@ async fn test_group_wide_property_update() {
     });
 
     // Create first connection
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder().socket_address(addr).build()],
         TransportProperties::default(),
@@ -106,7 +106,7 @@ async fn test_conn_priority_not_shared() {
     });
 
     // Create first connection
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder().socket_address(addr).build()],
         TransportProperties::default(),
@@ -172,7 +172,7 @@ async fn test_keepalive_timeout_setting() {
     });
 
     // Create connection
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder().socket_address(addr).build()],
         TransportProperties::default(),
@@ -232,7 +232,7 @@ async fn test_keepalive_timeout_setting() {
 #[tokio::test]
 async fn test_connection_timeout_setting() {
     // Create a connection without actually connecting
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder()
             .hostname("example.com")

--- a/src/tests/readonly_properties_tests.rs
+++ b/src/tests/readonly_properties_tests.rs
@@ -16,7 +16,7 @@ async fn create_test_connection() -> Connection {
     });
 
     // Create connection
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder().socket_address(addr).build()],
         TransportProperties::default(),
@@ -143,7 +143,7 @@ async fn test_unidirectional_send_connection() {
             .direction(CommunicationDirection::UnidirectionalSend)
             .build();
 
-        let preconn = new_preconnection(
+        let preconn = Preconnection::new(
             vec![],
             vec![RemoteEndpoint::builder().socket_address(addr).build()],
             transport_props,
@@ -201,7 +201,7 @@ async fn test_unidirectional_receive_connection() {
             .direction(CommunicationDirection::UnidirectionalReceive)
             .build();
 
-        let preconn = new_preconnection(
+        let preconn = Preconnection::new(
             vec![],
             vec![RemoteEndpoint::builder().socket_address(addr).build()],
             transport_props,

--- a/src/tests/rendezvous_tests.rs
+++ b/src/tests/rendezvous_tests.rs
@@ -1,8 +1,8 @@
 //! Unit tests for Rendezvous functionality
 
 use crate::{
-    preconnection::new_preconnection, ConnectionState, EndpointIdentifier, LocalEndpoint,
-    RemoteEndpoint, SecurityParameters, TransportProperties,
+    ConnectionState, EndpointIdentifier, LocalEndpoint, Preconnection, RemoteEndpoint,
+    SecurityParameters, TransportProperties,
 };
 use std::time::Duration;
 use tokio::time::{sleep, timeout};
@@ -10,7 +10,7 @@ use tokio::time::{sleep, timeout};
 #[tokio::test]
 async fn test_rendezvous_requires_endpoints() {
     // Test with no local endpoints
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![], // No local endpoints
         vec![RemoteEndpoint {
             identifiers: vec![EndpointIdentifier::Port(8080)],
@@ -28,7 +28,7 @@ async fn test_rendezvous_requires_endpoints() {
         .contains("No local endpoints"));
 
     // Test with no remote endpoints
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![LocalEndpoint {
             identifiers: vec![EndpointIdentifier::Port(8080)],
         }],
@@ -62,7 +62,7 @@ async fn test_rendezvous_basic() {
         protocol: None,
     };
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![local],
         vec![remote],
         TransportProperties::default(),
@@ -99,7 +99,7 @@ async fn test_rendezvous_resolve() {
         protocol: None,
     };
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![local],
         vec![remote],
         TransportProperties::default(),
@@ -145,7 +145,7 @@ async fn test_rendezvous_simultaneous_connect() {
         protocol: None,
     };
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![local],
         vec![remote],
         TransportProperties::default(),
@@ -196,7 +196,7 @@ async fn test_rendezvous_incoming_connection() {
         protocol: None,
     };
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![local],
         vec![remote],
         TransportProperties::default(),
@@ -264,7 +264,7 @@ async fn test_rendezvous_multiple_endpoints() {
         },
     ];
 
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         locals,
         remotes,
         TransportProperties::default(),

--- a/src/tests/settable_properties_tests.rs
+++ b/src/tests/settable_properties_tests.rs
@@ -16,7 +16,7 @@ async fn create_test_connection() -> Connection {
     });
 
     // Create connection
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder().socket_address(addr).build()],
         TransportProperties::default(),

--- a/src/tests/tcp_properties_tests.rs
+++ b/src/tests/tcp_properties_tests.rs
@@ -16,7 +16,7 @@ async fn create_test_connection() -> Connection {
     });
 
     // Create connection
-    let preconn = new_preconnection(
+    let preconn = Preconnection::new(
         vec![],
         vec![RemoteEndpoint::builder().socket_address(addr).build()],
         TransportProperties::default(),
@@ -311,7 +311,7 @@ async fn test_tcp_properties_group_synchronization() {
         });
 
         // Create first connection
-        let preconn = new_preconnection(
+        let preconn = Preconnection::new(
             vec![],
             vec![RemoteEndpoint::builder().socket_address(addr).build()],
             TransportProperties::default(),


### PR DESCRIPTION
Removed the redundant `new_preconnection()` free function that was just forwarding to `Preconnection::new()` without any additional logic. Updated all 100+ test occurrences to directly use `Preconnection::new()` instead. This simplifies the API by providing only one way to create a Preconnection instance. All tests continue to pass without any issues.

🤖 Generated with [Claude Code](https://claude.ai/code)